### PR TITLE
qfix: Add missend sendfd registry client

### DIFF
--- a/internal/pkg/imports/imports_linux.go
+++ b/internal/pkg/imports/imports_linux.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/ipam/singlepointipam"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	_ "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/debug"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log"

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/ipam/singlepointipam"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	registrysendfd "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/tools/debug"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -222,7 +223,14 @@ func main() {
 		}
 	}
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, &cfg.ConnectTo, registryclient.WithDialOptions(clientOptions...))
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(
+		ctx,
+		&cfg.ConnectTo,
+		registryclient.WithDialOptions(clientOptions...),
+		registryclient.WithNSEAdditionalFunctionality(
+			registrysendfd.NewNetworkServiceEndpointRegistryClient(),
+		),
+	)
 	nse := getNseEndpoint(listenOn, cfg)
 
 	nse, err = nseRegistryClient.Register(ctx, nse)


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

We've removed `sendfd` from default registry/chains because NSM can be used in non-k8s systems. Now we need to add for each k8s nse app `sendfd` as additional functionality 